### PR TITLE
hiding the confidence icon and authority value from submission fixes #32

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -199,7 +199,7 @@
          <repeatable>false</repeatable>
          <label>OpenAIRE Project Identifier</label>
          <input-type>onebox</input-type>
-         <hint>Start typing the number, name or acronym of the European project (EC / ERC) and select the project from suggestions.</hint>
+         <hint>Start typing the number, name or acronym of the European project (EC / ERC). Select the project from suggestions; you need to enter at least 4 characters; only the first 10 matches are shown.</hint>
          <acl>          	          	        	
            	policy=deny,action=read,grantee-type=user,grantee-id=*
          </acl>                    

--- a/dspace/modules/xmlui/src/main/webapp/themes/UFAL/lib/css/authority-control.css
+++ b/dspace/modules/xmlui/src/main/webapp/themes/UFAL/lib/css/authority-control.css
@@ -9,7 +9,7 @@
 /* this magic gets the 16x16 icon to show up.. setting height/width didn't
    do it, but adding padding actually made it show up. */
 img.ds-authority-confidence
-{ width: 16px; height: 16px; margin: 0px 2px; padding: 0px; display: inline-block;}
+{ width: 16px; height: 16px; margin: 0px 2px; padding: 0px; display: none;}
 
 img.ds-authority-confidence.cf-unset
   { background: transparent url(../../images/authority_control/confidence/bug.png); }
@@ -52,3 +52,4 @@ input.ds-authority-lock.is-unlocked
 span.ds-dc_contributor_author-authority { color: #982521; }
 
 #aspect_general_ChoiceLookupTransformer_div_lookup select {height: auto;}
+#aspect_submission_StepTransformer_field_dc_relation_authority {display: none !important;}


### PR DESCRIPTION
This hides the confidence icon and authority value from submission, as we currently have no use for them...