### PR TITLE
adding new local metadata files.count and files.size

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -1093,21 +1093,31 @@ public class Item extends DSpaceObject
             }
         }
         
+        int totalNumberOfFiles = 0;
+        long totalSizeofFiles = 0;
+        
         /* Add local.has.files metadata */
         boolean hasFiles = false;
         Bundle[] origs = getBundles("ORIGINAL");
         for(Bundle orig : origs) {
         	if(orig.getBitstreams().length > 0) {
         		hasFiles = true;
-        		break;
+        	}        	
+        	for(Bitstream bit : orig.getBitstreams()) {
+        		totalNumberOfFiles ++;
+        		totalSizeofFiles += bit.getSize();
         	}
         }
         clearMetadata("local", "has", "files", Item.ANY);
+        clearMetadata("local", "files", "count", Item.ANY);
+        clearMetadata("local", "files", "size", Item.ANY);
         if(hasFiles) {
         	addMetadata("local", "has", "files", Item.ANY, "yes");
         } else {
         	addMetadata("local", "has", "files", Item.ANY, "no");
         }
+        addMetadata("local", "files", "count", Item.ANY, "" + totalNumberOfFiles);
+        addMetadata("local", "files", "size", Item.ANY, "" + totalSizeofFiles);
 
         if (modifiedMetadata || modified)
         {
@@ -2167,3 +2177,4 @@ public class Item extends DSpaceObject
 		}
 	}
 }
+

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/aspect/artifactbrowser/item-list.xsl
@@ -156,14 +156,14 @@
             </xsl:choose>
             <div class="label label-info" style="margin-bottom: 20px;">
                 <xsl:variable name="file-size"
-                    select="sum(mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file/@SIZE)" />
+                    select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/dim:field[@mdschema='local' and @element='files' and @qualifier='count']/node()" />
                 <xsl:variable name="formatted-file-size">
                     <xsl:call-template name="format-size">                   
                         <xsl:with-param name="size" select="$file-size" />
                     </xsl:call-template>
                 </xsl:variable>
                 <xsl:variable name="file-count"
-                    select="count(mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file)" />
+                    select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/dim:field[@mdschema='local' and @element='files' and @qualifier='count']/node()" />
                 <i class="fa fa-paperclip">&#160;</i>
                 <i18n:translate>
                     <xsl:choose>
@@ -495,5 +495,6 @@
     </xsl:template>    
             
 </xsl:stylesheet>
+
 
 

--- a/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/utils.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFAL/lib/xsl/core/utils.xsl
@@ -39,7 +39,7 @@
             <xsl:text>cocoon:/</xsl:text>
             <xsl:value-of select="@url"/>
             <!-- Since this is a summary only grab the descriptive metadata, and the thumbnails -->
-            <!-- xsl:text>?sections=dmdSec,fileSec&amp;fileGrpTypes=THUMBNAIL</xsl:text-->
+            <xsl:text>?sections=dmdSec,amdSec&amp;fileGrpTypes=THUMBNAIL</xsl:text>
             <!-- An example of requesting a specific metadata standard (MODS and QDC crosswalks only work for items)->
             <xsl:if test="@type='DSpace Item'">
                 <xsl:text>&amp;dmdTypes=DC</xsl:text>
@@ -160,4 +160,5 @@
     </xsl:template>
 
 </xsl:stylesheet>
+
 

--- a/dspace-xmlui/src/main/webapp/themes/UFALHome/lib/xsl/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/UFALHome/lib/xsl/page-structure.xsl
@@ -385,7 +385,8 @@
 							<xsl:variable name="externalMetadataURL">
 								<xsl:text>cocoon:/</xsl:text>
 								<xsl:value-of select="@url" />
-								<!-- No options selected, render the full METS document -->
+								<!-- only grab the descriptive metadata, no files section -->
+								<xsl:text>?sections=dmdSec,amdSec</xsl:text>
 							</xsl:variable>
 							<xsl:apply-templates select="document($externalMetadataURL)" mode="recentList" />
 						</xsl:if>
@@ -418,15 +419,13 @@
 				</xsl:when>
 			</xsl:choose>
 			<div class="label label-info" style="margin-bottom: 20px;">
-                <xsl:variable name="file-size"
-                    select="sum(mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file/@SIZE)" />
+                <xsl:variable name="file-size" select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/dim:field[@mdschema='local' and @element='files' and @qualifier='count']/node()" />
                 <xsl:variable name="formatted-file-size">
                     <xsl:call-template name="format-size">                   
                         <xsl:with-param name="size" select="$file-size" />
                     </xsl:call-template>
                 </xsl:variable>
-                <xsl:variable name="file-count"
-                    select="count(mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file)" />
+                <xsl:variable name="file-count" select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/dim:field[@mdschema='local' and @element='files' and @qualifier='count']/node()" />
                 <i class="fa fa-paperclip">&#160;</i>
                 <i18n:translate>
                     <xsl:choose>
@@ -610,7 +609,8 @@
 									<xsl:text>cocoon://metadata</xsl:text>
 									<xsl:value-of select="substring-after(dri:xref/@target, $context-path)" />
 									<xsl:text>/mets.xml</xsl:text>
-									<!-- No options selected, render the full METS document -->
+									<!-- only grab the descriptive metadata, no files section -->
+									<xsl:text>?sections=dmdSec,amdSec</xsl:text>
 								</xsl:variable>
 								<xsl:apply-templates select="document($externalMetadataURL)"
 									mode="recentList" />
@@ -895,5 +895,6 @@
 	</div>	
 	</xsl:template>
 </xsl:stylesheet>
+
 
 

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -69,4 +69,17 @@
     	<schema>local</schema>
     	<element>genre</element>
     </dc-type>
+    <dc-type>
+        <schema>local</schema>
+        <element>files</element>
+        <qualifier>size</qualifier>
+        <scope_note>Size of all the files in the item in bytes</scope_note>
+    </dc-type>
+	<dc-type>
+        <schema>local</schema>
+        <element>files</element>
+        <qualifier>count</qualifier>
+        <scope_note>Count of files in the item</scope_note>
+    </dc-type>                            
 </dspace-dc-types>
+


### PR DESCRIPTION
After deploying this pull request the following actions are required to test this:

1. adding of the new metadata
sudo make update_metadata_scheme

2. running the addfiledata curation task
sudo [installation_dir]/bin/dspace curate -t addfiledata -i all