### PR TITLE
Issue 355

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
@@ -17,10 +17,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.authorize.ResourcePolicy;
-import org.dspace.core.ConfigurationManager;
-import org.dspace.core.Constants;
-import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.*;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.storage.rdbms.DatabaseManager;
@@ -698,5 +695,14 @@ public class WorkspaceItem implements InProgressSubmission
     public void setPublishedBefore(boolean b)
     {
         wiRow.setColumn("published_before", b);
+    }
+
+    public String getShareToken() {
+        String token = wiRow.getStringColumn("share_token");
+        if(token == null || token.equals("")){
+            token  = Utils.generateHexKey();
+            wiRow.setColumn("share_token", token);
+        }
+        return token;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -520,6 +520,11 @@ public class DatabaseUtils
         // We will now check prior versions in reverse chronological order, looking
         // for specific tables or columns that were newly created in each version.
 
+        if(tableColumnExists(connection, "workspaceitem", "share_token"))
+        {
+            return "5.3.2015.09.18";
+        }
+
         // Is this pre-DSpace 5.0 (with Metadata 4 All changes)? Look for the "resource_id" column in the "metadatavalue" table
         if(tableColumnExists(connection, "metadatavalue", "resource_id"))
         {

--- a/dspace-api/src/main/java/org/dspace/submit/AbstractProcessingStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/AbstractProcessingStep.java
@@ -79,6 +79,9 @@ public abstract class AbstractProcessingStep
      **************************************************************************/
     public static final String PROGRESS_BAR_PREFIX = "submit_jump_";
 
+    //Name of Save & Share button
+    public static final String SAVE_SHARE_BUTTON = "submit_save_share";
+
     /***************************************************************************
      * Flag which specifies that the LAST PAGE of a step has been reached. This
      * flag is used when a Workflow Item is rejected (and returned to the

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V5.3_2015.09.18__Token_for_WorkspaceItem.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V5.3_2015.09.18__Token_for_WorkspaceItem.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workspaceitem ADD share_token varchar(32);

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/DisplayShareLink.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/DisplayShareLink.java
@@ -1,0 +1,61 @@
+package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.ProcessingException;
+import org.apache.cocoon.environment.SourceResolver;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.authorize.AuthorizeException;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class DisplayShareLink  extends AbstractDSpaceTransformer{
+    private static final Message T_title 				= message("Share link");
+    private static final Message T_trail 				= message("Share link");
+    private static final Message T_head 				= message("Share link");
+    private static final Message T_para 				= message("To pass your submission to another user give them the following link: {0}");
+
+    private static final Message T_DSPACE_HOME		= message("xmlui.general.dspace_home");
+
+    private String link;
+
+    @Override
+    public void setup(SourceResolver resolver, Map objectModel, String src,
+                      Parameters parameters) throws ProcessingException, SAXException,
+            IOException {
+        super.setup(resolver, objectModel, src, parameters);
+        this.link = parameters.getParameter("link", null);
+    }
+
+    @Override
+    public void addPageMeta(PageMeta pageMeta) throws SAXException,
+            WingException, SQLException, IOException,
+            AuthorizeException
+    {
+        pageMeta.addMetadata("title").addContent(T_title);
+
+        pageMeta.addTrailLink(contextPath + "/", T_DSPACE_HOME);
+        pageMeta.addTrailLink(null, T_trail);
+    }
+
+    @Override
+    public void addBody(Body body) throws SAXException, WingException,
+            SQLException, IOException, AuthorizeException {
+
+        Division div = body.addDivision("share_submission_link");
+        div.setHead(T_head);
+        if(link != null){
+            div.addPara(T_para.parameterize(link));
+        }
+        else{
+            throw new AuthorizeException("Not authorized");
+        }
+    }
+}

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/OwnerChangeForm.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/OwnerChangeForm.java
@@ -76,8 +76,15 @@ public class OwnerChangeForm extends AbstractDSpaceTransformer {
         if(eperson == null || eperson.getID() < 1){
             throw new AuthorizeException("You are not authorized to view this page.");
         }
+
         if(id != -1){
-            Item item = WorkspaceItem.find(context, id).getItem();
+            WorkspaceItem wi = WorkspaceItem.find(context, id);
+            Item item = wi.getItem();
+            Request request = ObjectModelHelper.getRequest(objectModel);
+            String paramToken = request.getParameter("share_token");
+            if(paramToken == null || paramToken.equals("") || !wi.getShareToken().equals(paramToken)){
+                throw new AuthorizeException("Invalid token.");
+            }
             EPerson sub = item.getSubmitter();
             div.addPara(String.format("This items currently belongs to %s (%s)", sub.getFullName(), sub.getEmail()));
             div.addList("buttons-list").addItem().addButton("submit_own").setValue("Take It");

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/OwnerChangeForm.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/OwnerChangeForm.java
@@ -1,0 +1,88 @@
+package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit;
+
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.ProcessingException;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.ContextUtil;
+import org.dspace.app.xmlui.utils.UIException;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class OwnerChangeForm extends AbstractDSpaceTransformer {
+
+    private static final Message T_title 				= message("Change submitter");
+    private static final Message T_trail 				= message("Change submitter");
+    private static final Message T_head 				= message("Change submitter");
+
+    private static final Message T_DSPACE_HOME		= message("xmlui.general.dspace_home");
+    protected ConfigurationService configurationService;
+
+    private int id;
+
+    @Override
+    public void setup(SourceResolver resolver, Map objectModel, String src,
+                      Parameters parameters) throws ProcessingException, SAXException,
+            IOException {
+        super.setup(resolver, objectModel, src, parameters);
+        DSpace dspace = new DSpace();
+        configurationService = dspace.getConfigurationService();
+        this.id = parameters.getParameterAsInteger("id", -1);
+    }
+
+    @Override
+    public void addPageMeta(PageMeta pageMeta) throws SAXException,
+            WingException, UIException, SQLException, IOException,
+            AuthorizeException
+    {
+        pageMeta.addMetadata("title").addContent(T_title);
+
+        pageMeta.addTrailLink(contextPath + "/", T_DSPACE_HOME);
+        pageMeta.addTrailLink(null, T_trail);
+    }
+
+    @Override
+    public void addBody(Body body) throws SAXException, WingException,
+            UIException, SQLException, IOException, AuthorizeException {
+
+        Division div = body.addInteractiveDivision("take_item", contextPath + "/submit/" + knot.getId() + ".continue", Division.METHOD_POST, "primary administrative");
+        div.setHead(T_head);
+        Context context = ContextUtil.obtainContext(objectModel);
+        EPerson eperson = context.getCurrentUser();
+        if(eperson == null || eperson.getID() < 1){
+            throw new AuthorizeException("You are not authorized to view this page.");
+        }
+        if(id != -1){
+            Item item = WorkspaceItem.find(context, id).getItem();
+            EPerson sub = item.getSubmitter();
+            div.addPara(String.format("This items currently belongs to %s (%s)", sub.getFullName(), sub.getEmail()));
+            div.addList("buttons-list").addItem().addButton("submit_own").setValue("Take It");
+            div.addHidden("submission-continue").setValue(knot.getId());
+        }
+
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/AbstractStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/AbstractStep.java
@@ -83,6 +83,9 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
         message("xmlui.Submission.general.default.title");
     protected static final Message T_default_trail = 
         message("xmlui.Submission.general.default.trail");
+
+    protected static final Message T_save_share =
+            message("xmlui.Submission.general.submission.save_share");
     
     
     /** Progress Bar Language Strings */
@@ -351,6 +354,8 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
         
         // always show "Save/Cancel"
         actions.addButton(AbstractProcessingStep.CANCEL_BUTTON).setValue(T_save);
+        // always show "Save & Share"
+        actions.addButton(AbstractProcessingStep.SAVE_SHARE_BUTTON).setValue(T_save_share);
         
         // If last step, show "Complete Submission"
         if(isLastStep())

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -424,7 +424,7 @@ public class FlowUtils {
         return listStepNumbers.toArray(new StepAndPage[listStepNumbers.size()]);
     }
 
-    public static void shareSubmission(Map objectModel, String workspaceID) throws IOException, AuthorizeException, SQLException, MessagingException {
+    public static String shareSubmission(Map objectModel, String workspaceID) throws IOException, AuthorizeException, SQLException, MessagingException {
         Context context = ContextUtil.obtainContext(objectModel);
         if(workspaceID.startsWith("S")){
             workspaceID = workspaceID.substring(1);
@@ -447,5 +447,6 @@ public class FlowUtils {
         email2User.addArgument(link);
 
         email2User.send();
+        return link;
     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumeStep.java
@@ -46,7 +46,9 @@ public class ResumeStep extends AbstractStep
         message("xmlui.Submission.submit.ResumeStep.submit_resume");
     protected static final Message T_submit_cancel = 
         message("xmlui.general.cancel");
-  
+	protected static final Message T_submit_share =
+			message("xmlui.Submission.submit.ResumeStep.submit_share");
+
 	/**
 	 * Establish our required parameters, abstractStep will enforce these.
 	 */
@@ -98,5 +100,6 @@ public class ResumeStep extends AbstractStep
 		org.dspace.app.xmlui.wing.element.Item actions = form.addItem();
 		actions.addButton("submit_resume").setValue(T_submit_resume);
 		actions.addButton("submit_cancel").setValue(T_submit_cancel);
+		actions.addButton("submit_share").setValue(T_submit_share);
 	}
 }

--- a/dspace-xmlui/src/main/resources/aspects/Submission/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/sitemap.xmap
@@ -28,6 +28,7 @@
       <!-- <map:transformer name="SelectCollectionStep" src="org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep"/> -->
       <map:transformer name="SelectCollectionStep" src="cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep"/>
       <map:transformer name="OwnerChange" src="cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit.OwnerChangeForm"/>
+      <map:transformer name="DisplayShareLink" src="cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit.DisplayShareLink"/>
       <!-- </UFAL> -->
       <map:transformer name="ResumeStep" src="org.dspace.app.xmlui.aspect.submission.submit.ResumeStep"/>
       <map:transformer name="SaveOrRemoveStep" src="org.dspace.app.xmlui.aspect.submission.submit.SaveOrRemoveStep"/>
@@ -245,6 +246,12 @@
             <map:match pattern="handle/*/*/submit/ownerChange">
               <map:transform type="OwnerChange">
                 <map:parameter name="id" value="{flow-attribute:id}"/>
+              </map:transform>
+            </map:match>
+
+            <map:match pattern="submit/displayShareLink">
+              <map:transform type="DisplayShareLink">
+                <map:parameter name="link" value="{flow-attribute:link}"/>
               </map:transform>
             </map:match>
 

--- a/dspace-xmlui/src/main/resources/aspects/Submission/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/sitemap.xmap
@@ -27,6 +27,7 @@
       <!-- <UFAL> -->
       <!-- <map:transformer name="SelectCollectionStep" src="org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep"/> -->
       <map:transformer name="SelectCollectionStep" src="cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep"/>
+      <map:transformer name="OwnerChange" src="cz.cuni.mff.ufal.dspace.app.xmlui.aspect.submission.submit.OwnerChangeForm"/>
       <!-- </UFAL> -->
       <map:transformer name="ResumeStep" src="org.dspace.app.xmlui.aspect.submission.submit.ResumeStep"/>
       <map:transformer name="SaveOrRemoveStep" src="org.dspace.app.xmlui.aspect.submission.submit.SaveOrRemoveStep"/>
@@ -240,7 +241,13 @@
                 <map:parameter name="handle" value="{flow-attribute:handle}"/>
               </map:transform>
             </map:match>
-            
+
+            <map:match pattern="handle/*/*/submit/ownerChange">
+              <map:transform type="OwnerChange">
+                <map:parameter name="id" value="{flow-attribute:id}"/>
+              </map:transform>
+            </map:match>
+
           </map:match> <!-- flow match-->
           
           <!-- javascript libraries and utils for choice/authority-control -->

--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -234,6 +234,14 @@ function doSubmission()
                    getDSContext().complete();
                    cocoon.exit();
                }
+               else if (cocoon.request.get("submit_share"))
+               {
+                    FlowUtils.shareSubmission(getObjectModel(), workspaceID);
+                    var contextPath = cocoon.request.getContextPath();
+                    cocoon.redirectTo(contextPath+"/submissions",true);
+                    getDSContext().complete();
+                    cocoon.exit();
+               }
 
 
            } while (1 == 1)
@@ -242,7 +250,6 @@ function doSubmission()
        }
        else{
            //change the submitter if "checks" pass
-           //TODO we should at least send an email, this might expose submission data without proper license
            do {
                sendPageAndWait("handle/" + handle + "/submit/ownerChange",
                    {"id": workspaceID});

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -737,6 +737,7 @@
 	<message key="xmlui.Submission.general.showsimple">Show simple item record</message>
 	<message key="xmlui.Submission.general.default.title">Submission</message>
 	<message key="xmlui.Submission.general.default.trail">Submission</message>
+	<message key="xmlui.Submission.general.submission.save_share">Save &amp; Share</message>
 
 	<!-- org.dspace.app.xmlui.submission.CollectionViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Submit a new item to this collection</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -824,6 +824,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resume</message>
+	<message key="xmlui.Submission.submit.ResumeStep.submit_share">Share submission</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
 	<message key="xmlui.Submission.submit.SelectCollection.head">Select a collection</message>

--- a/dspace/config/emails/share_submission
+++ b/dspace/config/emails/share_submission
@@ -1,0 +1,21 @@
+# E-mail with a download link
+#
+# Parameters: {0} is expanded to submission link
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: ${lr.dspace.name.short}: Submission share link
+To pass your submission to another user give them the following link:
+ {0}
+
+If you have trouble please contact
+${lr.help.mail} or call us at ${lr.help.phone}
+
+
+${lr.dspace.name.short} Team
+
+_____________________________________
+${dspace.name},
+WWW: ${dspace.url}
+Email: ${lr.help.mail}
+Tel.: ${lr.help.phone}


### PR DESCRIPTION
resolves #355 

added new button when you are on a submission
![image](https://cloud.githubusercontent.com/assets/1842385/9988152/642f8218-604e-11e5-92ab-e370d659ec76.png)

clicking it generates an email, eg.
```
Date: Mon, 21 Sep 2015 10:49:33 +0200 (CEST)
From: dspace-noreply@ufal.mff.cuni.cz
To: dspace@lindat.cz
Subject: VAGRANT Demo LINDAT/CLARIN: Submission share link

To pass your submission to another user give them the following link:
 http://dspace.lindat.dev/xmlui/submit?workspaceID=895&share_token=9d9645cc29512ab69dd45f6867dc37d5

If you have trouble please contact
dspace-help@dspace.lindat.dev or call us at +420-22191-4366


VAGRANT Demo LINDAT/CLARIN Team

_____________________________________
Vagrants DEMO of LINDAT/CLARIN digital library at Institute of Formal and Applied Linguistics, Charles University in Prague (vdspace-vagrant),
WWW: http://dspace.lindat.dev/xmlui
Email: dspace-help@dspace.lindat.dev
Tel.: +420-22191-4366

```
following the link as a different user takes you to a new page where you can take the submission
![image](https://cloud.githubusercontent.com/assets/1842385/9988206/d03998d6-604e-11e5-9d3e-bc671bfb7e3d.png)

you can take it and resume the submission.
The token is generated only once (it stays until the item is submitted) so in theory the link can be shared with more people. It was not tested what happens when one person is editing a submission an another one takes it from him.
An exception will probably be thrown if the person taking the item does not have submit rights for the collection the item is in (should also be tested).