### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ before_install:
   - whoami
   - java -version
   - pwd
+  - free -m -t
   - mvn help:system
+  - free -m -t
   - export FS=`pwd`
   -     echo "########################"
   - if which cloc; then cloc ../; else echo "No cloc"; fi
@@ -46,6 +48,10 @@ script:
 - "cd $FS/utilities/project_helpers/config"
 - "cp local.conf.dist ../sources/local.properties"
 - "cd $FS"
+- "free -m -t"
 - "mvn clean package -Dmaven.test.skip=true -P !dspace -B -V"
+- "free -m -t"
 - "mvn install license:check -Dmaven.test.skip=false -P !dspace -B -V"
+- "free -m -t"
 - "mvn package -P dspace,!assembly,!dspace-xmlui-mirage2 -B -V"
+- "free -m -t"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,51 @@
 language: java
-sudo: required
+sudo: false
+
+env:
+    - MAVEN_OPTS=-Xmx1024M
 
 addons:
-  postgresql: "9.4"
+    apt:
+        packages:
+            - cloc
 
 before_install:
-  - sudo rm /etc/mavenrc
-  - export MAVEN_OPTS="-Dmaven.repo.local=/home/travis/.m2/repository -Xmx2048M -XX:MaxPermSize=256m"
+  # https://github.com/travis-ci/travis-ci/issues/4629
+  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   -     echo "########################"
   - whoami
   - java -version
   - pwd
   - mvn help:system
   - export FS=`pwd`
-  - sudo apt-get install -qq cloc
   -     echo "########################"
-  - cloc ../
+  - if which cloc; then cloc ../; else echo "No cloc"; fi
   -     echo "########################"
 
-install:
-  - echo "Update settings"
-  - cd $FS/utilities/project_helpers
-  - sed -i'' 's/tomcat.(TOMCAT_VERSION)/travis/' ./config/variable.makefile.example
-  - sed -i'' 's/lr.common.theme = /lr.common.theme = \/tmp\/dspace/' ./config/local.conf.dist
-  - sed -i'' 's/dspace.install.dir = /dspace.install.dir = \/tmp\/dspace/' ./config/local.conf.dist
-  - cd $FS/utilities/project_helpers/config
-  - cp local.conf.dist ../sources/local.properties
-  - cd $FS/utilities/project_helpers/scripts
-  - echo "Creating dspace DB user and initialising databases"
-  - sudo -u postgres createuser --superuser dspace
-  - make create_databases
-  - echo "Installing prerequisites"
-  - make install_libs
-  - make new_deploy | grep -v "Download"
-  - make print_message
+# Skip install stage, as we'll do it below
+install: "echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'"
 
+# Two stage Build and Test
+# 1. Install & Unit Test APIs
+# 2. Assemble DSpace
 script:
-  - make test_dspace_database
-  - make test_utilities_database
-  - cd $FS/ && mvn -Dmaven.test.skip=false -Dtest=cz.cuni.mff.ufal.dspace.**.*Test,cz.cuni.mff.ufal.*Test -DfailIfNoTests=false test | grep -v "Download"
-  - cd $FS/utilities/project_helpers/scripts
-  - make tests
-  - #make selenium_tests || echo "Tests failed"
+# 1. [Install & Unit Test] Check source code licenses and run source code Unit Tests
+#    (This explicitly skips building the 'dspace' assembly module, since we only want to do that ONCE.)
+#        license:check => Validate all source code license headers
+#        -Dmaven.test.skip=false => Enable DSpace Unit Tests
+#        -P !dspace => SKIP full DSpace assembly (will do below)
+#        -B => Maven batch/non-interactive mode (recommended for CI)
+#        -V => Display Maven version info before build
+#- "mvn clean install license:check -Dmaven.test.skip=false -P !dspace -B -V"
+# 2. [Assemble DSpace] Ensure assembly process works (from [src]/dspace/), including Mirage 2
+#        -Dmirage2.on=true => Build Mirage2
+#        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
+#        -P !assembly => SKIP the actual building of [src]/dspace/dspace-installer (as it can be memory intensive)
+#- "cd dspace && mvn package -Dmirage2.on=false -P !assembly -B -V"
+
+- "cd $FS/utilities/project_helpers/config"
+- "cp local.conf.dist ../sources/local.properties"
+- "cd $FS"
+- "mvn clean package -Dmaven.test.skip=true -P !dspace -B -V"
+- "mvn install license:check -Dmaven.test.skip=false -P !dspace -B -V"
+- "mvn package -P dspace,!assembly,!dspace-xmlui-mirage2 -B -V"

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/AllCertsTrustManager.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/AllCertsTrustManager.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/DSpaceApi.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/DSpaceApi.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/ExtraLicenseField.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/ExtraLicenseField.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/Headers.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/Headers.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/Info.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/Info.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/IsoLangCodes.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/IsoLangCodes.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/LicensesDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/LicensesDisseminationCrosswalk.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/Logger.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/Logger.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/MissingLicenseAgreementException.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/MissingLicenseAgreementException.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/ORELicenseIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/ORELicenseIngestionCrosswalk.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/PiwikHelper.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/PiwikHelper.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal;
 
 import java.io.BufferedReader;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/PiwikPDFExporter.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/PiwikPDFExporter.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal;
 
 import java.awt.Color;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/checks/ImportantLogs.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/checks/ImportantLogs.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.checks;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/checks/ShibUserLogin.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/checks/ShibUserLogin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.checks;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/checks/ShibUserLogins.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/checks/ShibUserLogins.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.checks;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/AddBrandingMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/AddBrandingMetadata.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/AddFilesMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/AddFilesMetadata.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/AddLabelMetadata.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/AddLabelMetadata.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/FastLinkChecker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/FastLinkChecker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemHandleChecker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemHandleChecker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/ItemMetadataQAChecker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/OpenAIRE.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/OpenAIRE.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/UpdateDcDescriptionUri.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/curation/UpdateDcDescriptionUri.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.curation;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/AbstractPIDService.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/AbstractPIDService.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/IOUtils.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/IOUtils.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/PIDService.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/PIDService.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/PIDServiceEPICv2.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/PIDServiceEPICv2.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/util/ACE.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/util/ACE.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.util;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/util/ACL.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/app/util/ACL.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.util;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/authenticate/shibboleth/ShibEPerson.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/authenticate/shibboleth/ShibEPerson.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.authenticate.shibboleth;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/authenticate/shibboleth/ShibGroup.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/authenticate/shibboleth/ShibGroup.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.authenticate.shibboleth;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/authenticate/shibboleth/ShibHeaders.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/authenticate/shibboleth/ShibHeaders.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.authenticate.shibboleth;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/discovery/SolrServiceTweaksPlugin.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/discovery/SolrServiceTweaksPlugin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.discovery;
 
 import java.sql.SQLException;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/HandleComparatorFactory.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/HandleComparatorFactory.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDCommunityConfiguration.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDCommunityConfiguration.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDConfiguration.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDConfiguration.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDLogMiner.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDLogMiner.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDLogStatistics.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDLogStatistics.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDLogStatisticsEntry.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/PIDLogStatisticsEntry.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/Record.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/Record.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/RecordFileLineIterator.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/RecordFileLineIterator.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/RecordParser.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/RecordParser.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogEntry.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogEntry.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogEntryParser.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogEntryParser.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogFile.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogFile.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/DumpConfig.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/DumpConfig.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.runnable;
 
 import java.io.File;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/FixDuplicatedDemoUrl.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/FixDuplicatedDemoUrl.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.runnable;
 
 import java.io.Console;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/FixRightsLabel.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/runnable/FixRightsLabel.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.runnable;
 
 import java.sql.SQLException;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/sort/OrderFormatIsoLang.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/sort/OrderFormatIsoLang.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.sort;
 
 import org.dspace.sort.OrderFormatDelegate;

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/AdditionalInfoCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/AdditionalInfoCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/AssetstoreValidityCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/AssetstoreValidityCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/CuratorCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/CuratorCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/LogsCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/LogsCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/OAIPMHCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/OAIPMHCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/PIDCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/PIDCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/ShibbolethCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/ShibbolethCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/SubmissionRightsCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/SubmissionRightsCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/health/VLOCheck.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/health/VLOCheck.java
@@ -4,8 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- *
- * by lindat-dev team
  */
 package cz.cuni.mff.ufal.health;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikBitstreamTracker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikBitstreamTracker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikOAITracker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikOAITracker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikTracker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikTracker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikTrackerFactory.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/PiwikTrackerFactory.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/Tracker.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/Tracker.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/TrackerFactory.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/TrackerFactory.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/TrackingSite.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/tracker/TrackingSite.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.tracker;
 

--- a/dspace-api/src/main/java/org/dspace/content/authority/OpenAIREAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/OpenAIREAuthority.java
@@ -1,39 +1,9 @@
-/*
- * DCInputAuthority.java
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
  *
- * Version: $Revision: 1.1 $
- *
- * Date: $Date: 2009/07/23 05:07:01 $
- *
- * Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- * - Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *
- * - Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- *
- * - Neither the name of the DSpace Foundation nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
- * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- * DAMAGE.
+ * http://www.dspace.org/license/
  */
 /* Modified for LINDAT/CLARIN */
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V1.8_117.102.97.108__Upgrade_to_Lindat_Clarin_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V1.8_117.102.97.108__Upgrade_to_Lindat_Clarin_schema.sql
@@ -1,3 +1,11 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
 ALTER TABLE eperson ALTER COLUMN netid TYPE varchar(256);
 ALTER TABLE eperson ADD welcome_info varchar(30);
 ALTER TABLE eperson ADD last_login varchar(30);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V1.8_117.102.97.108__Upgrade_to_Lindat_Clarin_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V1.8_117.102.97.108__Upgrade_to_Lindat_Clarin_schema.sql
@@ -1,3 +1,11 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
 ALTER TABLE eperson ALTER COLUMN netid TYPE varchar(256);
 ALTER TABLE eperson ADD welcome_info varchar(30);
 ALTER TABLE eperson ADD last_login varchar(30);

--- a/dspace-api/src/test/java/cz/cuni/mff/ufal/PiwikHelperTest.java
+++ b/dspace-api/src/test/java/cz/cuni/mff/ufal/PiwikHelperTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal;
 
 import static org.junit.Assert.*;

--- a/dspace-api/src/test/java/cz/cuni/mff/ufal/ReportTest.java
+++ b/dspace-api/src/test/java/cz/cuni/mff/ufal/ReportTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-api/src/test/java/cz/cuni/mff/ufal/dspace/handle/PIDLogMinerTest.java
+++ b/dspace-api/src/test/java/cz/cuni/mff/ufal/dspace/handle/PIDLogMinerTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.handle;
 

--- a/dspace-api/src/test/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogFileTest.java
+++ b/dspace-api/src/test/java/cz/cuni/mff/ufal/dspace/logging/SimpleLogFileTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.logging;
 

--- a/dspace-oai/src/main/java/com/lyncode/xoai/dataprovider/OAIDataProvider.java
+++ b/dspace-oai/src/main/java/com/lyncode/xoai/dataprovider/OAIDataProvider.java
@@ -1,22 +1,10 @@
 /**
- * Copyright 2012 Lyncode
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * @author Development @ Lyncode <development@lyncode.com>
- * @version 3.1.0
+ * http://www.dspace.org/license/
  */
-
 package com.lyncode.xoai.dataprovider;
 
 import com.lyncode.xoai.dataprovider.core.OAIParameters;

--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/event/OAIIndexEventConsumer.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/event/OAIIndexEventConsumer.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.event;
 

--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/BibtexUtil.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/BibtexUtil.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.utils;
 

--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/ItemUtil.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/ItemUtil.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.utils;
 

--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/LicenseUtil.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/LicenseUtil.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.utils;
 

--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/XslLogUtil.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/utils/XslLogUtil.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.utils;
 

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Application.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/Application.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.rest;
 
 import org.glassfish.jersey.server.ResourceConfig;

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/ExportFormats.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/ExportFormats.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.rest;
 
 import org.dspace.core.ConfigurationManager;

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/FeaturedService.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/FeaturedService.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.rest;
 
 import java.util.Hashtable;

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/FeaturedServices.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/FeaturedServices.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.rest;
 
 import java.util.ArrayList;

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/RefBoxData.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/RefBoxData.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.rest;
 
 import cz.cuni.mff.ufal.dspace.rest.citation.formats.AbstractFormat;

--- a/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/citation/formats/AbstractFormat.java
+++ b/dspace-rest/src/main/java/cz/cuni/mff/ufal/dspace/rest/citation/formats/AbstractFormat.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.rest.citation.formats;
 
 import org.apache.commons.lang.StringUtils;

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -68,6 +68,8 @@
                         <exclude>**/DD_belated*</exclude>
                         <exclude>**/detectmobile*</exclude>
                         <exclude>**/sc-mobile*</exclude>
+                        <exclude>**/themes/UFAL/**</exclude>
+                        <exclude>**/themes/UFALHome/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/AllBitstreamZipArchiveReader.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/AllBitstreamZipArchiveReader.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/DSpaceXmluiApi.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/DSpaceXmluiApi.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/DiscoJuiceFeeds.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/DiscoJuiceFeeds.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/HandleRemoved.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/HandleRemoved.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/LicensePage.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/LicensePage.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/MissingAttributeTestFilter.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/MissingAttributeTestFilter.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/NoCacheServletFilter.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/NoCacheServletFilter.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/PiwikStatisticsReader.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/PiwikStatisticsReader.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal;
 
 import java.io.BufferedReader;

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/ShibError.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/ShibError.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/UFALLicenceAgreement.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/UFALLicenceAgreement.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/UFALLicenceAgreementAgreed.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/UFALLicenceAgreementAgreed.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/UFALUserValidation.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/UFALUserValidation.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /*
  * FROM RegistrationFinished.java
  */

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/EditItemLicenseForm.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/EditItemLicenseForm.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/EditItemServicesForm.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/EditItemServicesForm.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/LicenseForm.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/LicenseForm.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/UpdateEmbargoForm.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/administrative/UpdateEmbargoForm.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelBackupTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelBackupTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelBitstreams.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelBitstreams.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelConfigurationTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelConfigurationTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelCronJobTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelCronJobTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelEmbargo.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelEmbargo.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelJavaTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelJavaTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelLastLogin.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelLastLogin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelLicenseTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelLicenseTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelMetadata.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelMetadata.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelMetadataQA.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelMetadataQA.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelNotesTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelNotesTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelOAITab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelOAITab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelPIDTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelPIDTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelProgramsTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelProgramsTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelReplicationTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelReplicationTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 	

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelReplicationTabHelper.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelReplicationTabHelper.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 
 import java.io.File;

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelShibbolethTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelShibbolethTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelSignedLicenses.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelSignedLicenses.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelStatisticsTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelStatisticsTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelUnpublishedItemsTab.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelUnpublishedItemsTab.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/HtmlHelper.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/HtmlHelper.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/MainControlCheck.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/MainControlCheck.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/IsLoggingControlCheck.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/IsLoggingControlCheck.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.checks;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/LoggingControlCheck.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/LoggingControlCheck.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.checks;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/LoginControlCheck.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/LoginControlCheck.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.checks;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/ShibRawLoginControlCheck.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/checks/ShibRawLoginControlCheck.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.administrative.checks;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/artifactbrowser/BrowseGlobal.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/artifactbrowser/BrowseGlobal.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /* Created for LINDAT/CLARIN */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.artifactbrowser;
 

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/general/IfServiceManagerSelector.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/general/IfServiceManagerSelector.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.general;
 
 import java.sql.SQLException;

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/statistics/PiwikStatisticsTransformer.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/statistics/PiwikStatisticsTransformer.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.app.xmlui.aspect.statistics;
 
 import java.io.IOException;

--- a/dspace-xmlui/src/main/webapp/exception2html.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2html.xslt
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
 <!-- The contents of this file are subject to the license and copyright detailed 
 	in the LICENSE and NOTICE files at the root of the source tree and available 
 	online at http://www.dspace.org/license/ -->

--- a/dspace-xmlui/src/main/webapp/exceptionSessionExpired2html.xslt
+++ b/dspace-xmlui/src/main/webapp/exceptionSessionExpired2html.xslt
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
 <!-- The contents of this file are subject to the license and copyright detailed
     in the LICENSE and NOTICE files at the root of the source tree and available
     online at http://www.dspace.org/license/ -->

--- a/dspace-xmlui/src/main/webapp/static/js/controlpanel.js
+++ b/dspace-xmlui/src/main/webapp/static/js/controlpanel.js
@@ -1,3 +1,10 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 /*global jQuery */
 /*jshint globalstrict: true*/
 'use strict';

--- a/lr-b2safe-dspace/LICENSE_HEADER
+++ b/lr-b2safe-dspace/LICENSE_HEADER
@@ -1,0 +1,5 @@
+The contents of this file are subject to the license and copyright
+detailed in the LICENSE and NOTICE files at the root of the source
+tree and available online at
+
+http://www.dspace.org/license/

--- a/lr-b2safe-dspace/src/main/java/cz/cuni/mff/ufal/dspace/b2safe/HackedDataSet.java
+++ b/lr-b2safe-dspace/src/main/java/cz/cuni/mff/ufal/dspace/b2safe/HackedDataSet.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package cz.cuni.mff.ufal.dspace.b2safe;
 
 import fr.cines.eudat.repopack.b2safe_rp_core.DataObject;

--- a/lr-b2safe-dspace/src/main/java/cz/cuni/mff/ufal/dspace/b2safe/ItemModifyConsumer.java
+++ b/lr-b2safe-dspace/src/main/java/cz/cuni/mff/ufal/dspace/b2safe/ItemModifyConsumer.java
@@ -1,4 +1,11 @@
 /**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+/**
  * Institute of Formal and Applied Linguistics
  * Charles University in Prague, Czech Republic
  * 

--- a/lr-b2safe-dspace/src/main/java/cz/cuni/mff/ufal/dspace/b2safe/ReplicationManager.java
+++ b/lr-b2safe-dspace/src/main/java/cz/cuni/mff/ufal/dspace/b2safe/ReplicationManager.java
@@ -1,4 +1,11 @@
 /**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+/**
  * Institute of Formal and Applied Linguistics
  * Charles University in Prague, Czech Republic
  * 


### PR DESCRIPTION
added missing headers with `mvn license:format`
excluded themes/UFAL* from the headers check
.travis.yml without sudo -> on new architecture, it's more dspace like - unit tests + build process. It does not create or test the databases, it does not use the makefile.

mainly it passes https://travis-ci.org/ufal/lindat-dspace/builds/81577125