### PR TITLE
Enable redirects in VLOCheck

### DIFF
--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -147,7 +147,6 @@ lr.dspace.oai.url = ${dspace.baseUrl}/oai
 
 # page with info about harvesting the repository
 lr.harvester.info.url = ${harvesterInfo.url}
-lr.harvester.info.anchorName = ${harvesterInfo.anchorName}
 
 lr.default.eperson.language = en
 


### PR DESCRIPTION
Connections from URL class won't redirect from http to https, use HttpClient instead
fixes #407 