### PR TITLE
Issue 227

### DIFF
--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/AllBitstreamZipArchiveReader.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/AllBitstreamZipArchiveReader.java
@@ -305,7 +305,7 @@ public class AllBitstreamZipArchiveReader extends AbstractReader implements Recy
             {
                 name = "item_" + item.getID() + ".zip";
             }
-            response.setHeader("Content-Disposition", "attachment;filename=" + name);
+            response.setHeader("Content-Disposition", String.format("attachment;filename=\"%s\"",name));
             response.setContentType("application/zip");
 
             byte[] buffer = new byte[BUFFER_SIZE];

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/AllBitstreamZipArchiveReader.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/AllBitstreamZipArchiveReader.java
@@ -306,6 +306,7 @@ public class AllBitstreamZipArchiveReader extends AbstractReader implements Recy
                 name = "item_" + item.getID() + ".zip";
             }
             response.setHeader("Content-Disposition", "attachment;filename=" + name);
+            response.setContentType("application/zip");
 
             byte[] buffer = new byte[BUFFER_SIZE];
             int length = -1;


### PR DESCRIPTION
this fixes the issue for my version of firefox, however there still might be browsers where this is broken. http://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http goes to some length about Content-Disposition