### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ jdk:
   - oraclejdk8
 sudo: false
 
-env:
-    - MAVEN_OPTS=-Xmx1024M
-
 addons:
   postgresql: "9.4"
 
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/4629
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+  # https://github.com/travis-ci/travis-ci/issues/4613
+  - echo "MAVEN_OPTS='-Xmx4g -XX:MaxPermSize=1g'" > ~/.mavenrc
   - whoami
   - java -version
   - pwd
@@ -36,6 +35,7 @@ install: |
    free -m -t &&
    make install_libs &&
    free -m -t &&
+   make mvn_help &&
    make new_deploy | grep -v "Download" &&
    free -m -t &&
    make print_message

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ before_install:
   - pwd
   - mvn help:system
   - export FS=`pwd`
+  - rm -rf /tmp/dspace
 
 install: |
    echo "Update settings" &&
    cd $FS/utilities/project_helpers &&
    sed -i'' 's/tomcat.(TOMCAT_VERSION)/travis/' ./config/variable.makefile.example &&
-   sed -i'' 's/DIR_LINDAT_COMMON_THEME.*/DIR_LINDAT_COMMON_THEME :=\/tmp\/dspace/' ./config/variable.makefile.example &&
+   sed -i'' 's#DIR_LINDAT_COMMON_THEME.*#DIR_LINDAT_COMMON_THEME :=/tmp/dspace/lindat-common#' ./config/variable.makefile.example &&
    sed -i'' 's/dspace.install.dir = /dspace.install.dir = \/tmp\/dspace/' ./config/local.conf.dist &&
    cd $FS/utilities/project_helpers/config &&
    cp local.conf.dist ../sources/local.properties &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   - export FS=`pwd`
   - rm -rf /tmp/dspace
 
+# see https://github.com/travis-ci/travis-ci/issues/1066 for the && signs
+# yaml format: "When a string contains line breaks, you can use the literal style, indicated by the pipe (|), to indicate that the string will span several lines. In literals, newlines are preserved" (might not be necessary)
 install: |
    echo "Update settings" &&
    cd $FS/utilities/project_helpers &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk7
   - oraclejdk8
-sudo: false
+sudo: true
 
 addons:
   postgresql: "9.4"

--- a/utilities/project_helpers/scripts/makefile
+++ b/utilities/project_helpers/scripts/makefile
@@ -298,8 +298,7 @@ update_lindat_common:
 	    echo "Checking lindat common theme into $(DIR_LINDAT_COMMON_THEME)... "; \
 	    test -d $(DIR_LINDAT_COMMON_THEME)/.git || git clone $(URL_LINDAT_COMMON_GIT) --branch releases $(DIR_LINDAT_COMMON_THEME); \
 	    cd $(DIR_LINDAT_COMMON_THEME) && $(LINDAT_COMMON_THEME_FETCH); \
-	    rm -rf $(DIR_LINDAT_THEME_IN_WEBAPPS); \
-	    ln -s $(DIR_LINDAT_COMMON_THEME) $(DIR_LINDAT_THEME_IN_WEBAPPS); \
+	    ln -sf $(DIR_LINDAT_COMMON_THEME) $(DIR_LINDAT_THEME_IN_WEBAPPS); \
     fi
 
 #======================================================


### PR DESCRIPTION
Fixes several issues:

1. `Checking lindat common theme into /tmp/dspace... 
fatal: destination path '/tmp/dspace' already exists and is not an empty directory.
fatal: Not a git repository (or any of the parent directories): .git`
2. Our env MAVEN_OPTS were overridden in /etc/mavenrc
3. again uses the old infrastructure
    * at least works (for now)
    * seems to finish faster (for now)