### PR TITLE
use UTF-8 charset for all served javascript (.js) files

### DIFF
--- a/dspace-xmlui/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-xmlui/src/main/webapp/WEB-INF/web.xml
@@ -330,4 +330,9 @@
         <mime-type>text/plain</mime-type>
     </mime-mapping>
 
+    <mime-mapping>
+        <extension>js</extension>
+        <mime-type>application/javascript;charset=UTF-8</mime-type>
+    </mime-mapping>
+
 </web-app>


### PR DESCRIPTION
resolves #492 