### PR TITLE
#414 (Reserve PID in submission)

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/ConfigurableHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/handle/ConfigurableHandleIdentifierProvider.java
@@ -146,7 +146,7 @@ public class ConfigurableHandleIdentifierProvider extends IdentifierProvider {
     @Override
     public void reserve(Context context, DSpaceObject dso, String identifier) {
         try{
-            Handle handle = Handle.create( context, dso, identifier );
+            createNewIdentifier(context, dso, identifier);
         }catch(Exception e){
             log.error(LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -1402,7 +1402,6 @@ public abstract class DSpaceObject
         else
         {
             Collection collection = null;            
-
             if (type == Constants.COLLECTION)
             {
                 collection = (Collection) this;
@@ -1410,6 +1409,12 @@ public abstract class DSpaceObject
             else if (type == Constants.ITEM)
             {
                 collection = ((Item) this).getOwningCollection();
+                if(collection == null){
+                    WorkspaceItem wi = WorkspaceItem.findByItem(ourContext, (Item)this);
+                    if(wi != null){
+                        collection = wi.getCollection();
+                    }
+                }
             }
 
             if (collection != null)                

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -1864,7 +1864,10 @@ public class Item extends DSpaceObject
 		EPerson e = this.ourContext.getCurrentUser();
 		boolean canEditOwn = e != null && e.canEditSubmissionMetadata();
 		boolean isOwner = this.getSubmitter().equals(e);
-		boolean epersonIsReviewer = this.getOwningCollection().epersonIsReviewer();
+		boolean epersonIsReviewer = false;
+        if(this.getOwningCollection() != null ){
+            epersonIsReviewer = this.getOwningCollection().epersonIsReviewer();
+        }
 
         return (((ownersCanEditCollection || canEditOwn) && isOwner) || epersonIsReviewer);
 	}

--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/AddNewVersionAction.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/submission/submit/AddNewVersionAction.java
@@ -20,6 +20,8 @@ import org.apache.cocoon.environment.Redirector;
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.environment.SourceResolver;
 import org.apache.cocoon.environment.http.HttpEnvironment;
+import org.apache.log4j.Logger;
+import org.dspace.app.xmlui.aspect.submission.FlowUtils;
 import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Metadatum;
@@ -28,6 +30,7 @@ import org.dspace.content.WorkspaceItem;
 import org.dspace.core.Context;
 
 import cz.cuni.mff.ufal.dspace.IOUtils;
+import org.dspace.identifier.IdentifierException;
 
 /**
  * Create new version of existing archived submission. This action is used by the 
@@ -41,6 +44,7 @@ import cz.cuni.mff.ufal.dspace.IOUtils;
  */
 public class AddNewVersionAction extends AbstractAction
 {
+    private static Logger log = cz.cuni.mff.ufal.Logger.getLogger(AddNewVersionAction.class);
 
     private final static int SUBMISSION_THIRD_STEP = 3;
     
@@ -72,7 +76,7 @@ public class AddNewVersionAction extends AbstractAction
         	{        	    
     			Item item = Item.find(context, Integer.valueOf(itemID));
     			WorkspaceItem workspaceItem = WorkspaceItem.createByItem(context, item);
-    			fixMetadata(workspaceItem, item);
+    			fixMetadata(context,workspaceItem, item);
     			if(firstWorkspaceItem == null)
     			{
     			    firstWorkspaceItem = workspaceItem;
@@ -104,7 +108,7 @@ public class AddNewVersionAction extends AbstractAction
      * @throws AuthorizeException 
      * @throws SQLException 
      */
-    private void fixMetadata(WorkspaceItem workspaceItem, Item baseItem) throws SQLException, AuthorizeException, IOException 
+    private void fixMetadata(Context context, WorkspaceItem workspaceItem, Item baseItem) throws SQLException, AuthorizeException, IOException
     {
         Item item = workspaceItem.getItem();
         
@@ -134,7 +138,14 @@ public class AddNewVersionAction extends AbstractAction
         //item.clearMetadata("local", "branding", Item.ANY, Item.ANY);
         //this is a new item; discard old provenance records
         item.clearMetadata("dc", "description", "provenance", Item.ANY);
-        
+
+        //add new PID if enabled
+        try {
+            FlowUtils.reservePID(context, String.valueOf(workspaceItem.getID()));
+        } catch (IdentifierException e) {
+            log.error(e.getLocalizedMessage());
+        }
+
         item.update();        
         workspaceItem.update();    
     }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/AbstractStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/AbstractStep.java
@@ -56,7 +56,7 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
         message("xmlui.Submission.general.submission.title");
     protected static final Message T_submission_trail = 
         message("xmlui.Submission.general.submission.trail");
-    protected static final Message T_submission_head = 
+    protected static Message T_submission_head =
         message("xmlui.Submission.general.submission.head");
     protected static final Message T_previous = 
         message("xmlui.Submission.general.submission.previous");
@@ -182,6 +182,9 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
                     throw new ProcessingException(e);
                 }
                 this.submission = submissionInfo.getSubmissionItem();
+				if(this.submission != null && this.submission.getItem() != null){
+					T_submission_head = T_submission_head.parameterize(submission.getItem().getHandle());
+				}
             }
 			
 			// Check required error conditions
@@ -228,7 +231,7 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
 		if (submission instanceof WorkspaceItem)
 		{
 			pageMeta.addMetadata("title").addContent(T_submission_title);
-	
+
 			Collection collection = submission.getCollection();
 			
 	        pageMeta.addTrailLink(contextPath + "/",T_dspace_home);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -327,7 +327,7 @@ public class FlowUtils {
 			WorkspaceItem workspace = findWorkspace(context,id);
 			workspace.deleteAll();
 	        context.commit();
-		}else if (ConfigurationManager.getBooleanProperty("lr","handle.register.on.save",false)){
+		}else if (ConfigurationManager.getBooleanProperty("lr","lr.handle.register.on.save",false)){
 			FlowUtils.reservePID(context, id);
 			context.commit();
 		}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/FlowUtils.java
@@ -34,7 +34,10 @@ import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.*;
 import org.dspace.handle.HandleManager;
+import org.dspace.identifier.IdentifierException;
+import org.dspace.identifier.IdentifierService;
 import org.dspace.submit.AbstractProcessingStep;
+import org.dspace.utils.DSpace;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.WorkflowManager;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
@@ -448,4 +451,20 @@ public class FlowUtils {
         email2User.send();
         return link;
     }
+
+	public static String reservePID(Map objectModel, String workspaceID) throws IdentifierException, SQLException, AuthorizeException {
+		Context context = ContextUtil.obtainContext(objectModel);
+		if(workspaceID.startsWith("S")){
+			workspaceID = workspaceID.substring(1);
+		}
+		WorkspaceItem wi = WorkspaceItem.find(context, Integer.parseInt(workspaceID));
+		Item item = wi.getItem();
+		IdentifierService identifierService = new DSpace().getSingletonService(IdentifierService.class);
+		//TODO reserve(context, dso, id)
+		context.turnOffAuthorisationSystem();
+		identifierService.reserve(context, item);
+		item.update();
+		context.restoreAuthSystemState();
+		return item.getHandle();
+	}
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumeStep.java
@@ -48,6 +48,8 @@ public class ResumeStep extends AbstractStep
         message("xmlui.general.cancel");
 	protected static final Message T_submit_share =
 			message("xmlui.Submission.submit.ResumeStep.submit_share");
+	protected static final Message T_submit_reserve_pid =
+			message("xmlui.Submission.submit.ResumeStep.submit_reserve_pid");
 
 	/**
 	 * Establish our required parameters, abstractStep will enforce these.
@@ -101,5 +103,6 @@ public class ResumeStep extends AbstractStep
 		actions.addButton("submit_resume").setValue(T_submit_resume);
 		actions.addButton("submit_cancel").setValue(T_submit_cancel);
 		actions.addButton("submit_share").setValue(T_submit_share);
+		actions.addButton("submit_reserve_pid").setValue(T_submit_reserve_pid);
 	}
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumeStep.java
@@ -48,8 +48,6 @@ public class ResumeStep extends AbstractStep
         message("xmlui.general.cancel");
 	protected static final Message T_submit_share =
 			message("xmlui.Submission.submit.ResumeStep.submit_share");
-	protected static final Message T_submit_reserve_pid =
-			message("xmlui.Submission.submit.ResumeStep.submit_reserve_pid");
 
 	/**
 	 * Establish our required parameters, abstractStep will enforce these.
@@ -103,6 +101,5 @@ public class ResumeStep extends AbstractStep
 		actions.addButton("submit_resume").setValue(T_submit_resume);
 		actions.addButton("submit_cancel").setValue(T_submit_cancel);
 		actions.addButton("submit_share").setValue(T_submit_share);
-		actions.addButton("submit_reserve_pid").setValue(T_submit_reserve_pid);
 	}
 }

--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -238,6 +238,15 @@ function doSubmission()
                {
                    shareSubmission(workspaceID);
                }
+			   else if (cocoon.request.get("submit_reserve_pid"))
+			   {
+				   //TODO add user form
+				   FlowUtils.reservePID(getObjectModel(), workspaceID);
+                   var contextPath = cocoon.request.getContextPath();
+				   cocoon.redirectTo(contextPath+"/submit?workspaceID=" + workspaceID.substring(1), true);
+				   getDSContext().complete();
+				   cocoon.exit();
+			   }
 
 
            } while (1 == 1)

--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -238,15 +238,6 @@ function doSubmission()
                {
                    shareSubmission(workspaceID);
                }
-			   else if (cocoon.request.get("submit_reserve_pid"))
-			   {
-				   //TODO add user form
-				   FlowUtils.reservePID(getObjectModel(), workspaceID);
-                   var contextPath = cocoon.request.getContextPath();
-				   cocoon.redirectTo(contextPath+"/submit?workspaceID=" + workspaceID.substring(1), true);
-				   getDSContext().complete();
-				   cocoon.exit();
-			   }
 
 
            } while (1 == 1)
@@ -451,6 +442,7 @@ function submissionControl(collectionHandle, workspaceID, initStepAndPage)
                 {
                     FlowUtils.setBackPageReached(getDSContext(),workspaceID, step, page);
                 }
+				FlowUtils.processSaveOrRemove(getDSContext(), workspaceID, cocoon.request);
                 //share and exit
                 shareSubmission(workspaceID);
             }

--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -185,6 +185,8 @@ function doSubmission()
                        workspaceID = workspace.getID();
                        
                        collectionSelected = true;
+
+					   FlowUtils.reservePID(getDSContext(), workspaceID);
                         
                        break; // We don't need to ask them for a collection again.   
                    }
@@ -442,7 +444,6 @@ function submissionControl(collectionHandle, workspaceID, initStepAndPage)
                 {
                     FlowUtils.setBackPageReached(getDSContext(),workspaceID, step, page);
                 }
-				FlowUtils.processSaveOrRemove(getDSContext(), workspaceID, cocoon.request);
                 //share and exit
                 shareSubmission(workspaceID);
             }

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -722,7 +722,7 @@
     <message key="xmlui.Submission.general.go_mydspace">Go to My Home</message>
 	<message key="xmlui.Submission.general.submission.title">Item submission</message>
 	<message key="xmlui.Submission.general.submission.trail">Item submission</message>
-	<message key="xmlui.Submission.general.submission.head">Item submission</message>
+	<message key="xmlui.Submission.general.submission.head">Item submission {0}</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Previous</message>
 	<message key="xmlui.Submission.general.submission.save">Save &amp; Exit</message>
 	<message key="xmlui.Submission.general.submission.next">Next &gt;</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -823,7 +823,6 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resume</message>
 	<message key="xmlui.Submission.submit.ResumeStep.submit_share">Share submission</message>
-	<message key="xmlui.Submission.submit.ResumeStep.submit_reserve_pid">Obtain a PID before submission</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
 	<message key="xmlui.Submission.submit.SelectCollection.head">Select a collection</message>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -823,6 +823,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resume</message>
 	<message key="xmlui.Submission.submit.ResumeStep.submit_share">Share submission</message>
+	<message key="xmlui.Submission.submit.ResumeStep.submit_reserve_pid">Obtain a PID before submission</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
 	<message key="xmlui.Submission.submit.SelectCollection.head">Select a collection</message>

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -74,7 +74,7 @@ lr.pid.community.configurations = ${lr.pid.community.configurations}
 # if true, PID metadata will be filled with object metadata like title
 lr.pid.resolvemetadata = ${lr.pid.resolvemetadata}
 
-lr.handle.register.on.save = ${lr.handle.register.on.save}
+reserve.pid.on.start = ${lr.reserve.pid.on.start}
 
 ###### EUDAT replication ######
 # switched off by default

--- a/dspace/config/modules/lr.cfg
+++ b/dspace/config/modules/lr.cfg
@@ -74,6 +74,8 @@ lr.pid.community.configurations = ${lr.pid.community.configurations}
 # if true, PID metadata will be filled with object metadata like title
 lr.pid.resolvemetadata = ${lr.pid.resolvemetadata}
 
+lr.handle.register.on.save = ${lr.handle.register.on.save}
+
 ###### EUDAT replication ######
 # switched off by default
 lr.replication.eudat.protocol=${lr.replication.eudat.protocol}

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -732,7 +732,7 @@
 	<message key="xmlui.Submission.general.go_mydspace">Přejít na mou domovskou stránku</message>
 	<message key="xmlui.Submission.general.submission.title">Zaslání záznamu</message>
 	<message key="xmlui.Submission.general.submission.trail">Zaslání záznamu</message>
-	<message key="xmlui.Submission.general.submission.head">Zaslání záznamu</message>	
+	<message key="xmlui.Submission.general.submission.head">Zaslání záznamu {0}</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Předchozí</message>
 	<message key="xmlui.Submission.general.submission.save">Uložit a ukončit</message>
 	<message key="xmlui.Submission.general.submission.next">Další &gt;</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -835,7 +835,6 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Pokračovat</message>
 	<message key="xmlui.Submission.submit.ResumeStep.submit_share">Sdílet příspěvek</message>
-	<message key="xmlui.Submission.submit.ResumeStep.submit_reserve_pid">Získat PID před dokončením</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
 	<message key="xmlui.Submission.submit.SelectCollection.head">Vybrat kolekci</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -835,6 +835,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Pokračovat</message>
 	<message key="xmlui.Submission.submit.ResumeStep.submit_share">Sdílet příspěvek</message>
+	<message key="xmlui.Submission.submit.ResumeStep.submit_reserve_pid">Získat PID před dokončením</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
 	<message key="xmlui.Submission.submit.SelectCollection.head">Vybrat kolekci</message>

--- a/utilities/project_helpers/bits/messages.template
+++ b/utilities/project_helpers/bits/messages.template
@@ -703,7 +703,6 @@
   <!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
   <message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resume</message>
   <message key="xmlui.Submission.submit.ResumeStep.submit_share">Share submission</message>
-  <message key="xmlui.Submission.submit.ResumeStep.submit_reserve_pid">Obtain a PID before submission</message>
   <!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
   <message key="xmlui.Submission.submit.SelectCollection.head">Select a collection</message>
   <message key="xmlui.Submission.submit.SelectCollection.collection">Collection</message>

--- a/utilities/project_helpers/bits/messages.template
+++ b/utilities/project_helpers/bits/messages.template
@@ -703,6 +703,7 @@
   <!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
   <message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resume</message>
   <message key="xmlui.Submission.submit.ResumeStep.submit_share">Share submission</message>
+  <message key="xmlui.Submission.submit.ResumeStep.submit_reserve_pid">Obtain a PID before submission</message>
   <!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
   <message key="xmlui.Submission.submit.SelectCollection.head">Select a collection</message>
   <message key="xmlui.Submission.submit.SelectCollection.collection">Collection</message>

--- a/utilities/project_helpers/bits/messages.template
+++ b/utilities/project_helpers/bits/messages.template
@@ -605,7 +605,7 @@
   <message key="xmlui.Submission.general.go_mydspace">Go to My Home</message>
   <message key="xmlui.Submission.general.submission.title">Item submission</message>
   <message key="xmlui.Submission.general.submission.trail">Item submission</message>
-  <message key="xmlui.Submission.general.submission.head">Item submission</message>
+  <message key="xmlui.Submission.general.submission.head">Item submission {0}</message>
   <message key="xmlui.Submission.general.submission.previous">&lt; Previous</message>
   <message key="xmlui.Submission.general.submission.save">Save &amp; Exit</message>
   <message key="xmlui.Submission.general.submission.next">Next &gt;</message>

--- a/utilities/project_helpers/config/local.conf.dist
+++ b/utilities/project_helpers/config/local.conf.dist
@@ -23,6 +23,8 @@ handle.canonical.prefix = http://hdl.handle.net/
 handle.prefix = 123456789
 handle.dir=${dspace.dir}/handle-server
 
+lr.handle.register.on.save = false
+
 
 # UFAL mounted assetstore for restricted item harvesting. Please mind the trailing slash
 lr.harvestable.assetstore =

--- a/utilities/project_helpers/config/local.conf.dist
+++ b/utilities/project_helpers/config/local.conf.dist
@@ -23,7 +23,7 @@ handle.canonical.prefix = http://hdl.handle.net/
 handle.prefix = 123456789
 handle.dir=${dspace.dir}/handle-server
 
-lr.handle.register.on.save = false
+lr.reserve.pid.on.start = false
 
 
 # UFAL mounted assetstore for restricted item harvesting. Please mind the trailing slash


### PR DESCRIPTION
resolves #414 

Start a submission and save it. In resume step there is new button "Obtain a PID before submission".
If you've entered at least the Title you now see that the refbox has appeared and shows a pid.

We could complicate the flow bit more by allowing users to enter at least part of the PID, but I haven't seen much requests for that + it would mean adding more structure to the PIDs which should be opaque. 

(or we could make it easier and just reserve the handle on save...)