### PR TITLE
fix #592

### DIFF
--- a/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelSignedLicenses.java
+++ b/dspace-xmlui/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/aspect/administrative/ControlPanelSignedLicenses.java
@@ -73,7 +73,7 @@ public class ControlPanelSignedLicenses extends AbstractControlPanelTab
 			wfhead.addCellContent("BITSTREAM");
 			wfhead.addCellContent("EXTRA METADATA");
 			
-			java.util.List<LicenseResourceUserAllowance> licenses = functionalityManager.getSignedLicensesByDate();
+			java.util.List<LicenseResourceUserAllowance> licenses = functionalityManager.getSignedLicensesByDate(0,MAX_TO_SHOW);
 			
 			// hack for group by /////////
 			
@@ -95,8 +95,7 @@ public class ControlPanelSignedLicenses extends AbstractControlPanelTab
 			
 			/////////////////////////////
 			
-			int cnt = 1;
-			for (LicenseResourceUserAllowance license : licenses) 
+			for (LicenseResourceUserAllowance license : licenses)
 			{				
 				int bitstreamID = license.getLicenseResourceMapping().getBitstreamId();
 				LicenseDefinition ld = license.getLicenseResourceMapping().getLicenseDefinition();
@@ -157,11 +156,7 @@ public class ControlPanelSignedLicenses extends AbstractControlPanelTab
                 for(UserMetadata metadata : extraMetaData) {
                 	c.addHighlight("label label-info font_smaller").addContent(metadata.getMetadataKey() + ": " +metadata.getMetadataValue());
                 }
-                
-                if(++cnt > MAX_TO_SHOW) {
-                	break;
-                }
-			}						
+			}
 			
 		}catch( IllegalArgumentException e1 ) {
 			wftable.setHead( "No items - " + e1.getMessage() );

--- a/utilities/src/main/java/cz/cuni/mff/ufal/lindat/utilities/HibernateFunctionalityManager.java
+++ b/utilities/src/main/java/cz/cuni/mff/ufal/lindat/utilities/HibernateFunctionalityManager.java
@@ -459,6 +459,13 @@ public class HibernateFunctionalityManager implements IFunctionalities {
 	}
 
 	@Override
+	public List<LicenseResourceUserAllowance> getSignedLicensesByDate(int firstRecord, int limit) {
+		return (List<LicenseResourceUserAllowance>) hibernateUtil
+				.findByCriterieWithLimits(LicenseResourceUserAllowance.class, firstRecord, limit,
+						Order.desc("createdOn"));
+	}
+
+	@Override
 	public List<LicenseResourceUserAllowance> getSignedLicensesByUser(
 			int eperson_id) {
 		return (List<LicenseResourceUserAllowance>) hibernateUtil

--- a/utilities/src/main/java/cz/cuni/mff/ufal/lindat/utilities/interfaces/ILicenses.java
+++ b/utilities/src/main/java/cz/cuni/mff/ufal/lindat/utilities/interfaces/ILicenses.java
@@ -205,7 +205,9 @@ public interface ILicenses {
 	 * @return true if all went well.
 	 */	
 	public boolean defineLicenseLabel(String code, String title, boolean isExtended);
-	
+
+	public List<LicenseResourceUserAllowance> getSignedLicensesByDate(int firstRecord, int limit);
+
 	public List<LicenseResourceUserAllowance> getSignedLicensesByDate();
 	
 	public List<LicenseResourceUserAllowance> getSignedLicensesByUser(int eperson_id);

--- a/utilities/src/main/resources/cz/cuni/mff/ufal/lindat/utilities/hibernate/LicenseResourceUserAllowance.hbm.xml
+++ b/utilities/src/main/resources/cz/cuni/mff/ufal/lindat/utilities/hibernate/LicenseResourceUserAllowance.hbm.xml
@@ -7,10 +7,10 @@
             <column name="transaction_id" />
             <generator class="identity" />
         </id>
-        <many-to-one name="userRegistration" class="cz.cuni.mff.ufal.lindat.utilities.hibernate.UserRegistration" fetch="join" lazy="false">
+        <many-to-one name="userRegistration" class="cz.cuni.mff.ufal.lindat.utilities.hibernate.UserRegistration" fetch="select" lazy="false">
             <column name="eperson_id" not-null="true" />
         </many-to-one>
-        <many-to-one name="licenseResourceMapping" class="cz.cuni.mff.ufal.lindat.utilities.hibernate.LicenseResourceMapping" fetch="join" lazy="false">
+        <many-to-one name="licenseResourceMapping" class="cz.cuni.mff.ufal.lindat.utilities.hibernate.LicenseResourceMapping" fetch="select" lazy="false">
             <column name="mapping_id" not-null="true" />
         </many-to-one>
         <property name="createdOn" type="timestamp" generated="insert">


### PR DESCRIPTION
fixes #592 

The addition of limits seems to help. setMaxResults + fetchStrategy join + Criteria.DISTINCT_ROOT_ENTITY don't behave as one would expect at the first glance. If fetches the max results, but for some reason they are not unique, so the result transformer applied in the end will cause the list to have less than max results.

@amirkamran can you have a look at this? will the change in fetch strategy slow/break some other things?