### PR TITLE
Update OAIIndexEventConsumer

### DIFF
--- a/dspace-oai/src/main/java/cz/cuni/mff/ufal/event/OAIIndexEventConsumer.java
+++ b/dspace-oai/src/main/java/cz/cuni/mff/ufal/event/OAIIndexEventConsumer.java
@@ -118,6 +118,7 @@ public class OAIIndexEventConsumer implements Consumer {
      */
 	public void end(Context ctx) throws Exception {
 
+		Context anonymousContext = null;
 		try {
 			if (itemsToUpdate != null) {
 
@@ -133,7 +134,8 @@ public class OAIIndexEventConsumer implements Consumer {
 				// "free" the resources
 				itemsToUpdate = null;
 
-				XOAI indexer = new XOAI(ctx, false, false, false);
+				anonymousContext = new Context(Context.READ_ONLY);
+				XOAI indexer = new XOAI(anonymousContext, false, false, false);
 				AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(
 						new Class[] { BasicConfiguration.class });
 				applicationContext.getAutowireCapableBeanFactory()
@@ -144,6 +146,11 @@ public class OAIIndexEventConsumer implements Consumer {
 		} catch (Exception e) {
 			itemsToUpdate = null;
 			throw e;
+		}
+		finally {
+			if(anonymousContext!=null){
+				anonymousContext.complete();
+			}
 		}
 	}
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -300,9 +300,8 @@ public class XOAI {
     private boolean isPublic(Item item) {
         boolean pub = false;
         try {
-            //Check if anonymous READ access allowed on this Item
-            pub = AuthorizeManager.isAnIdenticalPolicyAlreadyInPlace(context, item, org.dspace.eperson.Group.ANONYMOUS_ID,
-                    Constants.READ, -1);
+            //Check if READ access allowed on this Item
+            pub = AuthorizeManager.authorizeActionBoolean(context, item, Constants.READ);
         } catch (SQLException ex) {
             log.error(ex.getMessage());
         }


### PR DESCRIPTION
resolves #991 
it passes an anonymous context to the XOAI (this normally happens when called from cli).
The change in XOAI is revert of the change introduced in d893959.
In effect this checks if the anonymous user has read allowed.