### PR TITLE
Fix for (some) pdf reports not being send

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -701,6 +701,7 @@ public class Email
         public BurstDelayQueue(int burstSize){
             super();
             this.burstSize = burstSize;
+	    log.info("BurstDelayQueue initiated with burstSize=" + burstSize);
         }
 
         @Override

--- a/utilities/project_helpers/scripts/makefile
+++ b/utilities/project_helpers/scripts/makefile
@@ -440,4 +440,4 @@ migrate_databases:
 	./migrate_db.sh $(UTILITIES_DATABASE_NAME)
 
 generate_piwik_reports:
-	LC_ALL=en_US.UTF-8 $(DSPACE_BIN) piwik-report-generator
+	LC_ALL=en_US.UTF-8 JAVA_OPTS="-Xmx2048m -Dfile.encoding=UTF-8 -Ddspace.lr.email.burst=32768" $(DSPACE_BIN) piwik-report-generator


### PR DESCRIPTION
With the default config the `lr.email.burst` is 20.  If clarin-dspace needs to send more than `lr.email.burst` mails, some of them get queued. The piwik-report-generator is a short lived process, it does not wait for the queue to be empty and exits. Hence any email in the queue is actually not sent.

This fix just changes `lr.email.burst` when calling `make generate_piwik_reports`. System properties have a rather low priority. If you have `lr.email.burst` in `config/modules/*.cfg` or `config/dspace.cfg` this fix will not work.