### PR TITLE
Issue 1252: fix strange xslt output in dim document

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/dim.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/dim.xsl
@@ -12,6 +12,8 @@
         </dim:dim>
     </xsl:template>
 
+    <xsl:template match="text()|@*"/>
+
     <xsl:template match="/doc:metadata/doc:element/doc:element/doc:element/doc:field[@name='value']">
         <xsl:call-template name="dimfield">
             <xsl:with-param name="mdschema" select="../../../@name"/>


### PR DESCRIPTION
Fixing the incorrect **dim** metadata output containing the strange **"restricted"** text in dim metadata output:

```
            <metadata>
                <dim:dim xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:doc="http://www.lyncode.com/xoai"
                         xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
                    ...
                    <dim:field mdschema="dc" element="title">Bohumír Lifka (librarian)</dim:field>
                    <dim:field mdschema="dc" element="type">clip</dim:field>
                    ...
                    <dim:field mdschema="local" element="language" qualifier="name">Nolinguistic content</dim:field>
                    <dim:field mdschema="local" element="files" qualifier="size" lang="*">241650171</dim:field>
                    <dim:field mdschema="local" element="files" qualifier="count" lang="*">2</dim:field>
                    <dim:field mdschema="metashare" element="ResourceInfo#ContentInfo" qualifier="mediaType">video</dim:field>
                    restricted
                </dim:dim>
            </metadata>
```
The fix:

Override the default <xsl:template>:
```
<xsl:template match="text()|@*">
  <xsl:value-of select="."/>
</xsl:template>
```
that **outputs the text content** of every element matching the root template XPath.

The new template just doesn't write anything to the output:
`<xsl:template match="text()|@*"/>`

See also the [Default Templates](https://www.data2type.de/xml-xslt-xslfo/math-ml/styles-transformations/xslt-primer/default-templates) document.

and

the [Templates priorities](https://www.kosek.cz/xml/xslt/zpracovani#zpracovani-priority)
