### PR TITLE
Fixing RequiredMetadataIT

### DIFF
--- a/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/RequiredMetadataIT.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Random;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
@@ -42,7 +43,7 @@ import org.junit.Test;
 public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
     private static final String TASK_NAME = "requiredmetadata";
 
-    private static final String HANDLE_COLLECTION = "123456789/113";
+    private static final String HANDLE_COLLECTION = "123456789/" + randomString();
     private static final String HANDLE_ITEM1 = HANDLE_COLLECTION + "-1";
     private static final String HANDLE_ITEM2 = HANDLE_COLLECTION + "-2";
     private static final String HANDLE_ITEM3 = HANDLE_COLLECTION + "-3";
@@ -135,6 +136,8 @@ public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
         identifierService.delete(context, item2, HANDLE_ITEM2);
         identifierService.delete(context, workspaceItem.getItem(), HANDLE_ITEM3);
         identifierService.delete(context, collection, HANDLE_COLLECTION);
+        workspaceItemService.deleteAll(context, workspaceItem);
+        collectionService.delete(context, collection);
         super.destroy();
     }
 
@@ -145,6 +148,12 @@ public class RequiredMetadataIT extends AbstractIntegrationTestWithDatabase {
 
     private static String successResultForItem(Item item) {
         return "Item: " + item.getHandle() + " has all required fields";
+    }
+
+    private static String randomString() {
+        Random r = new Random();
+        // Generate random integers in range 1000 to 1999
+        return String.valueOf(1000 + r.nextInt(1000));
     }
 
 }


### PR DESCRIPTION
This is fix for clarin-v7 integration-test error, that started to occur recently in regular builds.
```
java.lang.IllegalStateException: java.lang.IllegalStateException: Attempted to reuse a handle previously used by a COMMUNITY for a new COLLECTION
	at org.dspace.content.CollectionServiceImpl.create(CollectionServiceImpl.java:179)
	at org.dspace.content.CollectionServiceImpl.create(CollectionServiceImpl.java:137)
	at org.dspace.curate.RequiredMetadataIT.setUp(RequiredMetadataIT.java:70)
```

See: https://github.com/ufal/clarin-dspace/actions/runs/18114708576/job/51548095570