### PR TITLE
fixed ItemHandleCheckerIT test

### DIFF
--- a/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/ItemHandleCheckerIT.java
@@ -172,7 +172,9 @@ public class ItemHandleCheckerIT extends AbstractIntegrationTestWithDatabase {
         replaceHandleUrl(item3, HANDLE_INVALID);
         replaceHandleUrl(item4, HANDLE_URL_IGNORED);
         curator.curate(context, HANDLE_COLLECTION);
-        assertEquals(Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
+        // the final curator status is derived from the status of the latest checked item
+        // so the final curator status is unpredictable
+        // assertEquals(Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
         assertEquals(5, reporter.getReport().size());
         assertThat(reporter.getReport(), containsInAnyOrder(
                 is(""), // this one is for collection itself


### PR DESCRIPTION
For current implementation of "checkhandles", "checklinks" there's no reason to check the result status of the whole collection/community.
The **final curation status is the status of the last checked item**, which is unpredictable.

Instead, it would be good to provide some statistics.

Created new task for this feature: https://github.com/ufal/clarin-dspace/issues/1276
