### PR TITLE
Issue 1217: EPIC Handle API fix: add links to search response

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EpicHandleRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EpicHandleRestController.java
@@ -150,7 +150,7 @@ public class EpicHandleRestController extends DSpaceRestRepository<EpicHandleRes
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @RequestMapping(method = RequestMethod.GET, path = "{prefix}")
-    public Page<EpicHandleRest> search(@PathVariable String prefix, HttpServletRequest request) throws IOException {
+    public Page<EpicHandleResource> search(@PathVariable String prefix, HttpServletRequest request) throws IOException {
         if (prefix == null || prefix.isEmpty()) {
             throw new DSpaceBadRequestException("Epic handle prefix cannot be empty string");
         }
@@ -230,10 +230,10 @@ public class EpicHandleRestController extends DSpaceRestRepository<EpicHandleRes
         return converter.toRest(handle, projection);
     }
 
-    private Page<EpicHandleRest> getPage(List<Handle> handles, int page, int size, int totalElements) {
+    private Page<EpicHandleResource> getPage(List<Handle> handles, int page, int size, int totalElements) {
         Projection proj = utils.obtainProjection();
-        List<EpicHandleRest> restObjects = handles.stream()
-                .map(h -> toRest(h, proj))
+        List<EpicHandleResource> restObjects = handles.stream()
+                .map(h -> (EpicHandleResource) converter.toResource(toRest(h, proj)))
                 .collect(Collectors.toList());
         return new PageImpl<>(restObjects, PageRequest.of(page, size), totalElements);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EpicHandleRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EpicHandleRestController.java
@@ -232,10 +232,10 @@ public class EpicHandleRestController extends DSpaceRestRepository<EpicHandleRes
 
     private Page<EpicHandleResource> getPage(List<Handle> handles, int page, int size, int totalElements) {
         Projection proj = utils.obtainProjection();
-        List<EpicHandleResource> restObjects = handles.stream()
+        List<EpicHandleResource> epicHandleResources = handles.stream()
                 .map(h -> (EpicHandleResource) converter.toResource(toRest(h, proj)))
                 .collect(Collectors.toList());
-        return new PageImpl<>(restObjects, PageRequest.of(page, size), totalElements);
+        return new PageImpl<>(epicHandleResources, PageRequest.of(page, size), totalElements);
     }
 
     private static RuntimeException toDSpaceException(WebApplicationException ex) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EpicHandleRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EpicHandleRestControllerIT.java
@@ -116,11 +116,13 @@ public class EpicHandleRestControllerIT extends AbstractControllerIntegrationTes
                     .andExpect(jsonPath("$.content", containsInAnyOrder(
                             allOf(
                                     hasJsonPath("$.id", is("11148/TEST-0000-0011-2E03-7")),
-                                    hasJsonPath("$.url", is("http://www.test.cz/news"))
+                                    hasJsonPath("$.url", is("http://www.test.cz/news")),
+                                    hasJsonPath("$.links[0].href", endsWith("/epichandles/11148/TEST-0000-0011-2E03-7"))
                             ),
                             allOf(
                                     hasJsonPath("$.id", is("11148/TEST-0000-0011-2E07-3")),
-                                    hasJsonPath("$.url", is("http://www.test.cz/"))
+                                    hasJsonPath("$.url", is("http://www.test.cz/")),
+                                    hasJsonPath("$.links[0].href", endsWith("/epichandles/11148/TEST-0000-0011-2E07-3"))
                             )
                     )));
 


### PR DESCRIPTION
Fixed inconsistence in ePIC Handle API:


The GET request contains the ePIC handle link for a single response.
The search request not.

Fix: added links also to search request response.
