### PR TITLE
Issue-1084: allow existing users to use name/password authentication

### DIFF
--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -334,3 +334,10 @@ versioning.submitterCanCreateNewVersion = true
 # This property controls whether previous version of item should be unarchived when new item version is created.
 # By default, in DSpace, old item versions are unarchived
 versioning.unarchive.previous.version = false
+
+# Clarin-Dspace default authentication methods
+plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication,org.dspace.authenticate.clarin.ClarinShibAuthentication
+
+# self-registration(new registration), for the name/password authentication, is disabled
+# but existing users can still use the name/password authentication
+user.registration = false

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -335,7 +335,7 @@ versioning.submitterCanCreateNewVersion = true
 # By default, in DSpace, old item versions are unarchived
 versioning.unarchive.previous.version = false
 
-# Clarin-Dspace default authentication methods
+# CLARIN-DSpace default authentication methods
 plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication,org.dspace.authenticate.clarin.ClarinShibAuthentication
 
 # self-registration(new registration), for the name/password authentication, is disabled

--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -60,7 +60,7 @@
 
 # Authentication by Password (encrypted in DSpace's database). See authentication-password.cfg for default configuration.
 # Enabled by default (to disable, either comment out, or define a new list of AuthenticationMethod plugins in your local.cfg)
-plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication,org.dspace.authenticate.clarin.ClarinShibAuthentication
+plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
 
 
 #---------------------------------------------------------------#


### PR DESCRIPTION
Actions:

set
`user.registration = false`

to not allow new registrations, for name/password authentication

Move:
```
# Clarin-Dspace default authentication methods
plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication,org.dspace.authenticate.clarin.ClarinShibAuthentication
```
from authentication.cfg to clarin-dspace.cfg
 
With this change, existing users will be able to log-in with name/password, or even change password if required, but there will be no way, for new users to register.