### PR TITLE
Fixed ResourcePolicyRestRepositoryIT test failing after clock was switched to winter time

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.core.MediaType;
@@ -1703,7 +1704,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         calendar.set(Calendar.YEAR, 2010);
         calendar.set(Calendar.MONTH, 5);
         calendar.set(Calendar.DATE, 15);
-        calendar.set(Calendar.HOUR, 10);
 
         Date date = calendar.getTime();
 
@@ -1718,6 +1718,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Calendar calendar2 = Calendar.getInstance();
         SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
+
+        // java.util.Date() value is always stored as UTC Date (into SQL Date field)
+        // so the java.util.Date value formatted with this formatter and
+        // this (java.util.Date) value stored in the database will always match
+        formatDate.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         calendar2.set(Calendar.YEAR, 2021);
         calendar2.set(Calendar.MONTH, 2);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.core.MediaType;
@@ -1699,11 +1698,12 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Item item = ItemBuilder.createItem(context, collection).build();
 
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar calendar = Calendar.getInstance();
 
         calendar.set(Calendar.YEAR, 2010);
         calendar.set(Calendar.MONTH, 5);
         calendar.set(Calendar.DATE, 15);
+        calendar.set(Calendar.HOUR, 10);
 
         Date date = calendar.getTime();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.core.MediaType;
@@ -1698,7 +1699,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Item item = ItemBuilder.createItem(context, collection).build();
 
-        Calendar calendar = Calendar.getInstance();
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
         calendar.set(Calendar.YEAR, 2010);
         calendar.set(Calendar.MONTH, 5);


### PR DESCRIPTION
This is kind of the hot-fix.

Problem was when the test was started after midnight with the java.util.Date value of

Tue Jun 15 00:29:23 IST 2010

When this value is stored in the database - **resourcepolicy:startDate** [Date] field it's stored as "2010-06-14".
It's some issue with TimeZone

Later this java.util.Date value (long number) is formatted to Date string string, with the default TimeZone (in this case it returns 2010-06-15).

Then this value is compared with the value from database(which is 2010-06-14), and that's the reason why the test fails.


