### PR TITLE
Issue #1299 do not register 2 versioned identifier providers

### DIFF
--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -16,26 +16,6 @@
     <bean id="org.dspace.services.ConfigurationService"
           class="org.dspace.servicemanager.config.DSpaceConfigurationService" scope="singleton"/>
 
-    <!-- provider for exposing default Handle services implementaion. -->
-    <!--bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.HandleIdentifierProvider"
-          scope="singleton">
-        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
-    </bean-->
-
-<!-- Uncomment if you want to use the VersionedHandleIdentifierProvider as an identify provider. -->
-<!--    <bean id="org.dspace.identifier.VersionedHandleIdentifierProvider"-->
-<!--          class="org.dspace.identifier.VersionedHandleIdentifierProvider"-->
-<!--          scope="singleton">-->
-<!--        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>-->
-<!--    </bean>-->
-
-<!-- Comment it out if you do not want to use the ClarinVersionedHandleIdentifierProvider as an identify provider. -->
-    <bean id="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
-          class="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
-          scope="singleton">
-        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
-    </bean>
-
     <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true" scope="prototype"/>
 
     <!-- Register all our Flyway callback classes (which run before/after database migrations) -->

--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -16,6 +16,12 @@
     <bean id="org.dspace.services.ConfigurationService"
           class="org.dspace.servicemanager.config.DSpaceConfigurationService" scope="singleton"/>
 
+    <!-- provider for exposing default Handle services implementaion. -->
+    <!--bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.HandleIdentifierProvider"
+          scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean-->
+
     <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true" scope="prototype"/>
 
     <!-- Register all our Flyway callback classes (which run before/after database migrations) -->

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -331,3 +331,6 @@ webui.supported.locales = cs
 ##### S3 #####
 # S3 direct download is not used in the test environment
 s3.download.direct.enabled = false
+
+# Enable user registration for tests
+user.registration = true

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -30,7 +30,6 @@
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
 
-
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -17,9 +17,11 @@
            The VersionedHandleIdentifierProvider creates a new versioned
            handle for every new version.
            -->
+    <!--
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
+    -->
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -22,6 +22,15 @@
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
     -->
+
+    <!-- Comment it out if you do not want to use the ClarinVersionedHandleIdentifierProvider as an identify provider. -->
+    <bean id="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
+          class="org.dspace.identifier.ClarinVersionedHandleIdentifierProvider"
+          scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean>
+
+
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever


### PR DESCRIPTION
The **ClarinVersionedHandleIdentifierProvider** overrides the **VersionedHandleIdentifierProvider**, so there is no sense to register both.

Also moved ClarinVersionedHandleIdentifierProvider to identifier-service.xml.
