### PR TITLE
Issue 1295: Allow to submit item with only metadata - with no need to set Clarin License

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -109,10 +109,16 @@
         <!--Step will be to select a Creative Commons License -->
         <step-definition id="cclicense"> <heading>submit.progressbar.CClicense</heading>
             <processing-class>org.dspace.app.rest.submit.step.CCLicenseStep</processing-class>
-            <type>cclicense</type> 
+            <type>cclicense</type>
         </step-definition>
 
-        <step-definition id="extractionstep"> 
+        <step-definition id="clarin-license">
+            <heading>submit.progressbar.clarin-license</heading>
+            <processing-class>org.dspace.app.rest.submit.step.ClarinLicenseResourceStep</processing-class>
+            <type>clarin-license</type>
+        </step-definition>
+
+        <step-definition id="extractionstep">
             <heading>submit.progressbar.ExtractMetadataStep</heading>
             <processing-class>org.dspace.app.rest.submit.step.ExtractMetadataStep</processing-class>
             <type>extract</type>
@@ -219,6 +225,8 @@
             <!--Step will be to Sign off on the License -->
             <step id="license"/>
             <step id="cclicense"/>
+
+            <step id="clarin-license"/>
         </submission-process>
 
         <submission-process name="languagetestprocess">

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -331,3 +331,6 @@ webui.supported.locales = cs
 ##### S3 #####
 # S3 direct download is not used in the test environment
 s3.download.direct.enabled = false
+
+# Enable user registration for tests
+user.registration = true

--- a/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
@@ -41,13 +41,18 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
     }
 
     public static WorkspaceItemBuilder createWorkspaceItem(final Context context, final Collection col) {
-        WorkspaceItemBuilder builder = new WorkspaceItemBuilder(context);
-        return builder.create(context, col, null);
+        return createWorkspaceItem(context, col, null);
     }
 
     public static WorkspaceItemBuilder createWorkspaceItem(final Context context, final Collection col, UUID uuid) {
         WorkspaceItemBuilder builder = new WorkspaceItemBuilder(context);
-        return builder.create(context, col, uuid);
+        return builder.create(context, col, uuid).withClarinLicense();
+    }
+
+    public static WorkspaceItemBuilder createWorkspaceItemWithNoClarinLicense(final Context context,
+                                                                              final Collection col) {
+        WorkspaceItemBuilder builder = new WorkspaceItemBuilder(context);
+        return builder.create(context, col, null);
     }
 
     /**
@@ -224,6 +229,12 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
             handleException(e);
         }
         return this;
+    }
+
+    public WorkspaceItemBuilder withClarinLicense() {
+        addMetadataValue(MetadataSchemaEnum.DC.getName(), "rights", null, "GNU General Public Licence, version 3");
+        addMetadataValue(MetadataSchemaEnum.DC.getName(), "rights", "uri", "http://opensource.org/licenses/GPL-3.0");
+        return addMetadataValue(MetadataSchemaEnum.DC.getName(), "rights", "label", "PUB");
     }
 
     public WorkspaceItemBuilder withFulltext(String name, String source, InputStream is) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/ClarinLicenseResourceValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/ClarinLicenseResourceValidation.java
@@ -45,13 +45,15 @@ public class ClarinLicenseResourceValidation extends AbstractValidation {
         List<MetadataValue> licenseLabel = itemService.getMetadataByMetadataString(item, "dc.rights.label");
 
         List<ErrorRest> errors = new ArrayList<>();
-        if (CollectionUtils.isEmpty(licenseDefinition) || CollectionUtils.isEmpty(licenseName) ||
-            CollectionUtils.isEmpty(licenseLabel)) {
-            addError(errors, ERROR_VALIDATION_CLARIN_LICENSE_GRANTED,
-                    "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"
-                            + config.getId());
+        // check that if there are local files, the license fields are filled
+        if (hasFiles(item)) {
+            if (CollectionUtils.isEmpty(licenseDefinition) || CollectionUtils.isEmpty(licenseName) ||
+                    CollectionUtils.isEmpty(licenseLabel)) {
+                addError(errors, ERROR_VALIDATION_CLARIN_LICENSE_GRANTED,
+                        "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"
+                                + config.getId());
+            }
         }
-
 
         return errors;
     }
@@ -62,5 +64,14 @@ public class ClarinLicenseResourceValidation extends AbstractValidation {
 
     public void setItemService(ItemService itemService) {
         this.itemService = itemService;
+    }
+
+    private boolean hasFiles(Item item) {
+        List<MetadataValue> hasFiles = itemService.getMetadataByMetadataString(item, "local.has.files");
+        if (CollectionUtils.isEmpty(hasFiles)) {
+            return false;
+        } else {
+            return "yes".equalsIgnoreCase(hasFiles.get(0).getValue());
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseAddPatchOperationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseAddPatchOperationIT.java
@@ -53,7 +53,7 @@ public class CCLicenseAddPatchOperationIT extends AbstractControllerIntegrationT
                                                  .withName("Collection")
                                                  .build();
 
-        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, collection)
                                                           .withTitle("Workspace Item")
                                                           .build();
 
@@ -93,7 +93,7 @@ public class CCLicenseAddPatchOperationIT extends AbstractControllerIntegrationT
                                                  .withName("Collection")
                                                  .build();
 
-        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, collection)
                                                           .withTitle("Workspace Item")
                                                           .build();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseRemovePatchOperationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseRemovePatchOperationIT.java
@@ -53,7 +53,7 @@ public class CCLicenseRemovePatchOperationIT extends AbstractControllerIntegrati
                                                  .withName("Collection")
                                                  .build();
 
-        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, collection)
                                                           .withTitle("Workspace Item")
                                                           .build();
 
@@ -115,7 +115,7 @@ public class CCLicenseRemovePatchOperationIT extends AbstractControllerIntegrati
                                                  .withName("Collection")
                                                  .build();
 
-        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, collection)
                                                           .withTitle("Workspace Item")
                                                           .build();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseResourceValidationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseResourceValidationIT.java
@@ -1,0 +1,154 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.ItemService;
+import org.dspace.services.ConfigurationService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+/**
+ * Test suite for testing ClarinLicenseResourceValidation
+ * @author Milan Kuchtiak)
+ *
+ */
+public class ClarinLicenseResourceValidationIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private CollectionService cs;
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Test
+    public void createWorkspaceWithFiles_TitleAndClarinLicenseMissing() throws Exception {
+        context.turnOffAuthorisationSystem();
+        
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+
+        WorkspaceItem wItem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, col1)
+                .withIssueDate("2017-10-17")
+                .grantLicense()
+                .build();
+
+        InputStream pdf = getClass().getResourceAsStream("simple-article.pdf");
+        final MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+                "application/pdf", pdf);
+
+        context.restoreAuthSystemState();
+        // upload the file in our workspaceitem
+        getClient(authToken).perform(multipart("/api/submission/workspaceitems/" + wItem.getID())
+                        .file(pdfFile))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.title'][0].value",
+                        is("simple-article.pdf")))
+                .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.source'][0].value",
+                        is("/local/path/simple-article.pdf")))
+        ;
+
+        // Verify errors for missing title and clarin license
+        getClient(authToken).perform(get("/api/submission/workspaceitems/" + wItem.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors", hasSize(2)))
+                .andExpect(jsonPath("$.errors[?(@.message=='error.validation.required')]",
+                        contains( hasJsonPath("$.paths",
+                                contains(hasJsonPath("$", is("/sections/traditionalpageone/dc.title")))))))
+                .andExpect(jsonPath("$.errors[?(@.message=='error.validation.clarin-license.notgranted')]",
+                        contains( hasJsonPath("$.paths",
+                                contains(hasJsonPath("$", is("/sections/clarin-license")))))));
+    }
+
+    @Test
+    public void createWorkspaceWithoutFiles_UploadRequired() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, col1)
+                .withTitle("Test WorkspaceItem")
+                .withIssueDate("2017-10-17")
+                .build();
+
+        context.restoreAuthSystemState();
+        // Verify error for missing files (with upload required to be set to true)
+        // Also check whether there is no error for missing license.
+        // Since there are no files, the license is not required.
+        getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors", hasSize(1)))
+                .andExpect(jsonPath("$.errors[?(@.message=='error.validation.filerequired')]",
+                        contains(hasJsonPath("$.paths", contains(hasJsonPath("$", is("/sections/upload")))))));
+    }
+
+    @Test
+    public void createWorkspaceWithoutFiles_UploadNotRequired() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        configurationService.setProperty("webui.submit.upload.required", false);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItemWithNoClarinLicense(context, col1)
+                .withTitle("Test WorkspaceItem")
+                .withIssueDate("2017-10-17")
+                .build();
+
+        context.restoreAuthSystemState();
+        // Verify there is no errors (with upload required to be set to false).
+        // Since there are no files, the license is not required.
+        getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors").doesNotExist());
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseResourceValidationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseResourceValidationIT.java
@@ -28,13 +28,15 @@ import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;
 import org.dspace.services.ConfigurationService;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 
 /**
- * Test suite for testing ClarinLicenseResourceValidation
- * @author Milan Kuchtiak)
+ * Test suite for testing ClarinLicenseResourceValidation.
+ *
+ * @author Milan Kuchtiak
  *
  */
 public class ClarinLicenseResourceValidationIT extends AbstractControllerIntegrationTest {
@@ -45,6 +47,15 @@ public class ClarinLicenseResourceValidationIT extends AbstractControllerIntegra
     private ItemService itemService;
     @Autowired
     private ConfigurationService configurationService;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // make file upload mandatory in submissions
+        configurationService.setProperty("webui.submit.upload.required", true);
+    }
 
     @Test
     public void createWorkspaceWithFiles_TitleAndClarinLicenseMissing() throws Exception {
@@ -77,8 +88,7 @@ public class ClarinLicenseResourceValidationIT extends AbstractControllerIntegra
                 .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.title'][0].value",
                         is("simple-article.pdf")))
                 .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.source'][0].value",
-                        is("/local/path/simple-article.pdf")))
-        ;
+                        is("/local/path/simple-article.pdf")));
 
         // Verify errors for missing title and clarin license
         getClient(authToken).perform(get("/api/submission/workspaceitems/" + wItem.getID()))
@@ -144,7 +154,7 @@ public class ClarinLicenseResourceValidationIT extends AbstractControllerIntegra
                 .build();
 
         context.restoreAuthSystemState();
-        // Verify there is no errors (with upload required to be set to false).
+        // Verify there are no errors (with upload required to be set to false).
         // Since there are no files, the license is not required.
         getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
                 .andExpect(status().isOk())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseResourceValidationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ClarinLicenseResourceValidationIT.java
@@ -49,7 +49,7 @@ public class ClarinLicenseResourceValidationIT extends AbstractControllerIntegra
     @Test
     public void createWorkspaceWithFiles_TitleAndClarinLicenseMissing() throws Exception {
         context.turnOffAuthorisationSystem();
-        
+
         parentCommunity = CommunityBuilder.createCommunity(context)
                 .withName("Parent Community")
                 .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -205,7 +205,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                    // We expect the content type to be "application/hal+json;charset=UTF-8"
                    .andExpect(content().contentType(contentType))
                    // Match only that a section exists with a submission configuration behind
-                   .andExpect(jsonPath("$._embedded.submissionsections", hasSize(9)))
+                   .andExpect(jsonPath("$._embedded.submissionsections", hasSize(10)))
                    .andExpect(jsonPath("$._embedded.submissionsections",
                                        Matchers.hasItem(
                                            allOf(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -150,6 +150,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         adminGroup = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ADMIN);
 
         context.restoreAuthSystemState();
+
+        // make file upload mandatory in submissions
+        configurationService.setProperty("webui.submit.upload.required", true);
     }
 
     @Test

--- a/dspace/config/clarin-dspace.cfg
+++ b/dspace/config/clarin-dspace.cfg
@@ -341,3 +341,6 @@ plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authen
 # self-registration(new registration), for the name/password authentication, is disabled
 # but existing users can still use the name/password authentication
 user.registration = false
+
+# This option allows submitter to skip file upload step in the submission process
+webui.submit.upload.required = false


### PR DESCRIPTION
In case webui.submit.upload.required = false
the submitter can submit item with no files.

After the fix, there is no need to set Clarin License for item, when there are no files.
